### PR TITLE
Added hex<=> hex conversion. Example: F9 <=> FFAA55

### DIFF
--- a/lib/gcolor.js
+++ b/lib/gcolor.js
@@ -31,6 +31,8 @@ var GColor = (function () {
     fromHex: GColorFromHex,
     toHex: GColorToHex,
     toName: GColorName,
+    shortHex: GColorShortHex,
+    expandHex: GColorExpandHex,
 
     ArmyGreen             : 212,
     BabyBlueEyes          : 235,
@@ -131,4 +133,12 @@ var GColor = (function () {
     return null;
   }
 
+  function GColorShortHex(hex) {
+    return Number( GColorFromHex(hex) ).toString(16).toUpperCase();
+  }
+
+  function GColorExpandHex(hex) {
+    return GColorToHex( parseInt(hex, 16) );
+  }
+ 
 }());

--- a/test/tests.js
+++ b/test/tests.js
@@ -27,4 +27,22 @@ describe('GColor', function () {
       done();
     });
   });  
+  
+  describe('#expandHex', function () {
+    it('should convert a GColor hex value into a 6 character hex string', function (done) {
+      expect(GColor.expandHex('C0')).to.equal('000000');
+      expect(GColor.expandHex('FF')).to.equal('FFFFFF');
+      expect(GColor.expandHex('DB')).to.equal('55AAFF');
+      done();
+    });
+  });  
+  
+  describe('#shortHex', function () {
+    it('should convert a 6 character hex into a GColor 2 character hex string', function (done) {
+      expect(GColor.shortHex('000000')).to.equal('C0');
+      expect(GColor.shortHex('FFFFFF')).to.equal('FF');
+      expect(GColor.shortHex('55AA55')).to.equal('D9');
+      done();
+    });
+  });  
 });


### PR DESCRIPTION
Added two functions to convert between hex digits that represent GColor and six hex digits for HTML color representation.
Example: F9 <=> FFAA55
